### PR TITLE
Upgrade fourseven:scss dependency to 3.1.1

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
-  api.use("fourseven:scss@2.0.0", ["server"]);
+  api.use("fourseven:scss@3.1.1", ["server"]);
   api.imply("fourseven:scss", ["server"]);
 
   api.addFiles([


### PR DESCRIPTION
Use the latest version of fourseven:scss which uses libsass 3.1.1 bringing it almost to feature parity with Ruby Sass. Very important dependency for most using Sass in Meteor, shouldn't affect this package at all.
